### PR TITLE
Added dependency

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -53,6 +53,7 @@ Access the messages in your views via `locals.messages` (.jade in this case):
 
 ## Requires
 
+  * connect-flash
   * cookieParser
   * session
 


### PR DESCRIPTION
I know that this is probably painfully obvious to most - but for some reason I got it into my head that express-flash was a _replacement_ for connect-flash. And went on a hunt through my app for references to connect-flash once I started getting errors about it being missing. Once I saw the only reference was in express-flash.js, well, it clicked. Given that you're already listing dependencies I think it makes sense to mention it :)
