### PR TITLE
don't call req.flash() if there are no messages

### DIFF
--- a/lib/express-flash.js
+++ b/lib/express-flash.js
@@ -25,8 +25,15 @@ exports = module.exports = function () {
       var render = res.render;
       res.render = function () {
         // attach flash messages to res.locals.messages
-        res.locals.messages = req.flash();
-        render.apply(res, arguments);
+        // but only if messages exist in the session, we don't
+        // want empy sessions just for empty messages
+        if (req.session && req.session.flash) {
+            res.locals.messages = req.flash();
+            req.session.messages = undefined;
+        } else {
+            res.locals.messages = {};
+        }
+        render.apply(this, arguments);
       }
       next();
     })
@@ -38,4 +45,4 @@ exports = module.exports = function () {
  * Library version.
  */
 
-exports.version = '0.0.2';
+exports.version = '0.0.3';

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "express-flash",
-  "version": "0.0.2",
+  "version": "0.0.3",
   "description": "Flash Messages for your Express Application",
   "homepage": "https://github.com/RGBboy/express-flash",
   "keywords": ["express", "flash", "messages"],


### PR DESCRIPTION
Unfortunately req.flash() will set req.session.flash = {}, which might
start a session. It is better to keep it all uninitialized unless there are
actual messages to show.
