### PR TITLE
Add options that are passed to connect-flash

### DIFF
--- a/lib/express-flash.js
+++ b/lib/express-flash.js
@@ -8,7 +8,7 @@
  * Module Dependencies
  */
 
-var connectFlash = require('connect-flash')();
+var connectFlash = require('connect-flash');
 
 /**
  * Return a middleware function
@@ -16,10 +16,10 @@ var connectFlash = require('connect-flash')();
  * @return {Function} middleware function
  * @api public
  */
-exports = module.exports = function () {
+exports = module.exports = function (options) {
 
   return function (req, res, next) {
-    connectFlash(req, res, function () {
+    connectFlash(options)(req, res, function () {
       // Proxy the render function so that the flash is
       // retrieved right before the render function is executed
       var render = res.render;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "express-flash",
-  "version": "0.0.2",
+  "version": "0.0.3",
   "description": "Flash Messages for your Express Application",
   "homepage": "https://github.com/RGBboy/express-flash",
   "keywords": ["express", "flash", "messages"],


### PR DESCRIPTION
This allows one to initialize the middleware with unsafe:true
and suppress flash when desired by setting req.flash to a no-op
function.  I use this in controllers to prevent breaking res.render
when the session is being destroyed or is otherwise not initialized.