### PR TITLE
Name the middleware

### DIFF
--- a/lib/express-flash.js
+++ b/lib/express-flash.js
@@ -18,7 +18,7 @@ var connectFlash = require('connect-flash')();
  */
 exports = module.exports = function () {
 
-  return function (req, res, next) {
+  return function expressFlash(req, res, next) {
     connectFlash(req, res, function () {
       // Proxy the render function so that the flash is
       // retrieved right before the render function is executed


### PR DESCRIPTION
This prevents the `<anonymous>` layer name in the express stack.